### PR TITLE
Fix cron date and update README

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,7 +1,7 @@
 name: Update
 on:
   schedule:
-    - cron: "9 0 * * *"  # run at 09:00 UTC
+    - cron: "20 8 * * *" # run at 08:20 UTC
 jobs:
   update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why
Cron schedule is incorrect. We also want to use a less busy hour/minute combination to sidestep task congestion.

Data start date in README is incorrect.

## What
- Change cron schedule to 08:20 UTC.
- Data start date should be March 5, 2007.
- Add Workflow status badge to README.
- Flesh out README text with more caveats and explanations.
