### PR TITLE
Specify custom User-Agent in HTTP request headers

### DIFF
--- a/bin/update.py
+++ b/bin/update.py
@@ -507,9 +507,9 @@ def write_replace_json(file_path: Path, stocks: list[Stock], include_dates: bool
 
 
 def request_http(url: str, encoding: str = 'utf-8', request_headers: dict[str, str] | None = None) -> str:
+    headers = dict(request_headers or {})
+    headers.update({'User-Agent': _USER_AGENT})
     try:
-        headers = dict(request_headers or {})
-        headers.update({'User-Agent': _USER_AGENT})
         with urlopen(Request(url=url, headers=headers)) as resp:
             return resp.read().decode(encoding)
     except Exception as e:

--- a/bin/update.py
+++ b/bin/update.py
@@ -1,5 +1,3 @@
-# v1.1.0
-
 # pylint: disable=too-many-lines
 import csv
 from dataclasses import dataclass, field, fields, replace
@@ -20,6 +18,10 @@ from html_table_takeout import Table, parse_html
 
 
 T = TypeVar('T')
+
+
+_VERSION = '1.1.1'
+_USER_AGENT = f"Sp500ComponentsHistoryBot/{_VERSION}"
 
 
 COMPONENTS_HISTORY_FILE_NAME = 'components_history.csv'
@@ -506,10 +508,12 @@ def write_replace_json(file_path: Path, stocks: list[Stock], include_dates: bool
 
 def request_http(url: str, encoding: str = 'utf-8', request_headers: dict[str, str] | None = None) -> str:
     try:
-        with urlopen(Request(url=url, headers=request_headers or {})) as resp:
+        headers = dict(request_headers or {})
+        headers.update({'User-Agent': _USER_AGENT})
+        with urlopen(Request(url=url, headers=headers)) as resp:
             return resp.read().decode(encoding)
     except Exception as e:
-        raise IOError(f"Failed to make HTTP request. Error:{repr(e)}") from None
+        raise IOError(f"Failed to make HTTP request. Error:{repr(e)} Url: {url} Headers: {str(headers)}") from None
 
 
 def _fetch_tables(data_source: str = '') -> tuple[Table, Table, Revision]:

--- a/bin/update.py
+++ b/bin/update.py
@@ -21,7 +21,7 @@ T = TypeVar('T')
 
 
 _VERSION = '1.1.1'
-_USER_AGENT = f"Sp500ComponentsHistoryBot/{_VERSION}"
+_USER_AGENT = f"Sp500ComponentsHistoryBot/{_VERSION} (https://github.com/lawcal/sp500-components-history)"
 
 
 COMPONENTS_HISTORY_FILE_NAME = 'components_history.csv'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-html-table-takeout==1.1.1
+html-table-takeout==1.1.2


### PR DESCRIPTION
## Why
We are encountering `403 Forbidden` errors when making HTTP requests to Wikipedia.

This is because we neglected to include a custom `User-Agent` to identify our app. The default one added by `urllib` is too generic.

The guidelines for acceptable `User-Agent` strings are outlined in the [Wikimedia Foundation User-Agent Policy](https://foundation.wikimedia.org/wiki/Policy:Wikimedia_Foundation_User-Agent_Policy).

## What
- Always include a custom `User-Agent` in HTTP request headers identifying the app name, version and contact information (url of this repo).
- Bump dependency version.

## Testing

1. Run updater to retrieve latest updates.
2. There should not be any HTTP errors.
